### PR TITLE
[ISSUE-5] 주문 심사 도메인 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### Kotest TEST ###
 .jqwik-database
+
+### MySQL Docker ###
+/mysqldata

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,6 +35,7 @@ object Dependencies {
         const val redis = "org.springframework.boot:spring-boot-starter-data-redis"
         const val h2 = "com.h2database:h2"
         const val mysqlConnector = "mysql:mysql-connector-java"
+        const val envers = "org.springframework.data:spring-data-envers"
     }
 
     object Test {

--- a/cruel-app-web/src/main/resources/application.yml
+++ b/cruel-app-web/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+    config:
+        import: classpath:cruel-db.yml
     application:
         name: cruel-app-web
     profiles:

--- a/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatus.kt
+++ b/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatus.kt
@@ -3,6 +3,7 @@ package io.fana.cruel.core.type
 enum class OrderStatus {
     CREATED,
     CANCELED,
+    REJECTED,
     ACTIVATED,
     COMPLETED;
 }

--- a/cruel-domain-mysql/build.gradle.kts
+++ b/cruel-domain-mysql/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     implementation(Dependencies.Data.jpa)
     implementation(Dependencies.Data.jdsl)
+    implementation(Dependencies.Data.envers)
 
     runtimeOnly(Dependencies.Data.h2)
     runtimeOnly(Dependencies.Data.mysqlConnector)

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/common/LongRevisionEntity.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/common/LongRevisionEntity.kt
@@ -1,0 +1,60 @@
+package io.fana.cruel.domain.common
+
+import org.hibernate.envers.RevisionEntity
+import org.hibernate.envers.RevisionNumber
+import org.hibernate.envers.RevisionTimestamp
+import java.io.Serializable
+import java.text.DateFormat
+import java.util.Date
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.persistence.Transient
+
+/**
+ * PK를 Long 타입으로 사용하고 있으므로
+ * envers의 REV 타입을 변경하기 위해 사용한다.
+ */
+@Table(name = "REVINFO")
+@RevisionEntity
+@Entity
+class LongRevisionEntity() : Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @RevisionNumber
+    @Column(name = "REV")
+    var id: Long? = null
+
+    @RevisionTimestamp
+    @Column(name = "REVTSTMP")
+    var timestamp: Long? = null
+
+    constructor(id: Long, timestamp: Long) : this() {
+        this.id = id
+        this.timestamp = timestamp
+    }
+
+    @Transient
+    fun getRevisionDate() = timestamp?.let { Date(it) }
+
+    override fun toString(): String =
+        "LongRevisionEntity(id = $id, revisionDate = ${DateFormat.getDateTimeInstance().format(getRevisionDate())}"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LongRevisionEntity
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
@@ -7,6 +7,8 @@ import io.fana.cruel.domain.order.OrderInterestRate
 import io.fana.cruel.domain.order.OrderTerm
 import io.fana.cruel.domain.order.exception.InvalidOrderStatusException
 import io.fana.cruel.domain.user.domain.User
+import org.hibernate.envers.Audited
+import org.hibernate.envers.NotAudited
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import java.math.BigDecimal
@@ -33,6 +35,7 @@ import javax.persistence.Table
     ]
 )
 @Entity
+@Audited
 class Order(
     @ManyToOne
     @JoinColumn(
@@ -40,6 +43,7 @@ class Order(
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT),
         nullable = false
     )
+    @NotAudited
     val user: User,
 
     @Column(name = "amount", nullable = false)
@@ -52,6 +56,9 @@ class Order(
     @Column(name = "content", nullable = true, columnDefinition = "TEXT")
     val content: String? = null,
 ) : BaseEntity() {
+    @Column(name = "admin_id", nullable = true)
+    var adminId: Long? = null
+
     @Column(name = "interest_rate", nullable = false, precision = 6, scale = 3)
     var interestRate: BigDecimal = interestRate.rate
         private set
@@ -89,6 +96,12 @@ class Order(
     fun activated(): Order {
         requireOrderStatus(OrderStatus.CREATED, OrderStatus.ACTIVATED)
         status = OrderStatus.ACTIVATED
+        return this
+    }
+
+    fun rejected(): Order {
+        requireOrderStatus(OrderStatus.CREATED, OrderStatus.REJECTED)
+        status = OrderStatus.REJECTED
         return this
     }
 

--- a/cruel-domain-mysql/src/main/resources/cruel-db.yml
+++ b/cruel-domain-mysql/src/main/resources/cruel-db.yml
@@ -11,19 +11,20 @@ spring:
         generate-ddl: false
         open-in-view: false
         properties:
+            org:
+                hibernate:
+                    envers:
+                        audit_table_suffix: _audits
+                        revision_field_name: rev_id
+                        # envers delete 기록 삭제는 레코드가 null로 표기되지만,
+                        # delete 직전 해당 레코드의 필드를 남길 때 사용
+                        store_data_at_delete: true
             hibernate:
                 format_sql: false
                 show_sql: false
                 use_sql_comments: false
                 default_batch_fetch_size: 1000
         database-platform: org.hibernate.dialect.MySQL8Dialect
-        hibernate:
-            envers:
-                audit_table_suffix: _audits
-                revision_field_name: rev_id
-                # envers delete 기록 삭제는 레코드가 null로 표기되지만,
-                # delete 직전 해당 레코드의 필드를 남길 때 사용
-                store_data_at_delete: true
 ---
 spring:
     config:

--- a/cruel-domain-mysql/src/main/resources/cruel-db.yml
+++ b/cruel-domain-mysql/src/main/resources/cruel-db.yml
@@ -30,7 +30,7 @@ spring:
         activate:
             on-profile: local
     datasource:
-        url: jdbc:mysql://localhost:3306/platform
+        url: jdbc:mysql://localhost:3309/cruel
         username: root
         password: root
     jpa:

--- a/cruel-domain-mysql/src/main/resources/cruel-db.yml
+++ b/cruel-domain-mysql/src/main/resources/cruel-db.yml
@@ -1,0 +1,10 @@
+spring:
+    jpa:
+        org:
+            hibernate:
+                envers:
+                    audit_table_suffix: _audits
+                    revision_field_name: rev_id
+                    # envers delete 기록 삭제는 레코드가 null로 표기되지만,
+                    # delete 직전 해당 레코드의 필드를 남길 때 사용
+                    store_data_at_delete: true

--- a/cruel-domain-mysql/src/main/resources/cruel-db.yml
+++ b/cruel-domain-mysql/src/main/resources/cruel-db.yml
@@ -1,10 +1,55 @@
 spring:
+    config:
+        activate:
+            on-profile: common
+    datasource:
+        hikari:
+            pool-name: cruel-db-pool
+            maximum-pool-size: 10
+            transaction-isolation: TRANSACTION_READ_COMMITTED
     jpa:
-        org:
+        generate-ddl: false
+        open-in-view: false
+        properties:
             hibernate:
-                envers:
-                    audit_table_suffix: _audits
-                    revision_field_name: rev_id
-                    # envers delete 기록 삭제는 레코드가 null로 표기되지만,
-                    # delete 직전 해당 레코드의 필드를 남길 때 사용
-                    store_data_at_delete: true
+                format_sql: false
+                show_sql: false
+                use_sql_comments: false
+                default_batch_fetch_size: 1000
+        database-platform: org.hibernate.dialect.MySQL8Dialect
+        hibernate:
+            envers:
+                audit_table_suffix: _audits
+                revision_field_name: rev_id
+                # envers delete 기록 삭제는 레코드가 null로 표기되지만,
+                # delete 직전 해당 레코드의 필드를 남길 때 사용
+                store_data_at_delete: true
+---
+spring:
+    config:
+        activate:
+            on-profile: local
+    datasource:
+        url: jdbc:mysql://localhost:3306/platform
+        username: root
+        password: root
+    jpa:
+        generate-ddl: true
+        hibernate:
+            ddl-auto: update
+---
+spring:
+    config:
+        activate:
+            on-profile: develop
+    jpa:
+        hibernate:
+            ddl-auto: none
+---
+spring:
+    config:
+        activate:
+            on-profile: staging
+    jpa:
+        hibernate:
+            ddl-auto: none

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/domain/OrderStatusTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/domain/OrderStatusTest.kt
@@ -48,6 +48,31 @@ internal class OrderStatusTest : BehaviorSpec({
                 }
             }
         }
+        `when`("주문을 거절하면") {
+            then("주문이 거절된다") {
+                orderFixture.rejected()
+                orderFixture.status shouldBe OrderStatus.REJECTED
+            }
+            given("주문이 CREATED가 아닐 때") {
+                `when`("활성화된 주문의 거절을 시도하면") {
+                    val activatedOrder = orderFixture.activated()
+                    then("예외가 발생한다") {
+                        shouldThrow<InvalidOrderStatusException> {
+                            activatedOrder.rejected()
+                        }
+                    }
+                }
+                `when`("완료된 주문의 거절을 시도하면") {
+                    val activatedOrder = orderFixture.activated()
+                    val completedOrder = activatedOrder.completed()
+                    then("예외가 발생한다") {
+                        shouldThrow<InvalidOrderStatusException> {
+                            completedOrder.rejected()
+                        }
+                    }
+                }
+            }
+        }
         `when`("주문을 활성화하면") {
             then("주문이 활성화된다") {
                 orderFixture.activated()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.1'
+
+services:
+    cruel-db:
+        image: mysql:8.0.27
+        command: --default-authentication-plugin=mysql_native_password
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+        ports:
+            - '3309:3306'
+        volumes:
+            - ./dbdump/db:/docker-entrypoint-initdb.d
+            - ./mysqldata:/var/lib/mysql:rw,delegated
+        platform: linux/x86_64
+        networks:
+            - cruel


### PR DESCRIPTION
* ISSUE: [ISSUE-5](https://github.com/chunghwanyoon/cruel/issues/5)

## 변경 사항
- 뭐 따로 도메인을 추가한 것이 아니라 Order에 envers만 붙였고
- 누가 마지막 관리를 했는지 adminId와 상태 reject를 추가하였다.
  - 주문 도메인에 갑자기 adminId가 붙어서 좀 개이상하긴 한데 그냥 하기로 했다.
- 로컬 도커 mysql 추가
- mysql 도메인 설정 추가

## 체크 리스트
- [ ] 정상 동작 확인
- [ ] 테스트 작성
- [ ] 주석 및 문서 수정
