### PR TITLE
[ISSUE-9, ISSUE-10] 주문 관리 API 및 상환 스케쥴 계산 도메인 추가

### DIFF
--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderController.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderController.kt
@@ -1,0 +1,36 @@
+package io.fana.cruel.app.v1.admin.order.presentation
+
+import io.fana.cruel.core.type.DelayStatusSearchFilter
+import io.fana.cruel.core.type.OrderStatusSearchFilter
+import io.fana.cruel.domain.order.application.UpdateOrderService
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@Tag(name = "어드민 주문", description = "어드민 주문 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+class AdminOrderController(
+    private val updateOrderService: UpdateOrderService,
+) {
+    fun getOrders(
+        @RequestParam(defaultValue = "ALL") statusFilter: OrderStatusSearchFilter,
+        @RequestParam(defaultValue = "ALL") delayedFilter: DelayStatusSearchFilter,
+    ): List<AdminOrderResponse> {
+        TODO()
+    }
+
+    @PostMapping("/{orderId}/approve")
+    fun approveOrder(
+        @Parameter(name = "orderId", `in` = ParameterIn.PATH, description = "주문 ID")
+        @PathVariable("orderId") orderId: Long,
+    ): AdminOrderResponse {
+        return AdminOrderResponse.of(updateOrderService.approveOrder(orderId, LocalDateTime.now()))
+    }
+}

--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderResponse.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderResponse.kt
@@ -1,0 +1,34 @@
+package io.fana.cruel.app.v1.admin.order.presentation
+
+import io.fana.cruel.core.type.DelayStatus
+import io.fana.cruel.core.type.OrderStatus
+import io.fana.cruel.domain.order.domain.Order
+import java.math.BigDecimal
+
+data class AdminOrderResponse(
+    val id: Long,
+    val userId: Long,
+    val adminId: Long,
+    val amount: Int,
+    val interestRate: BigDecimal,
+    val term: Int,
+    val status: OrderStatus,
+    val content: String? = null,
+    val delayStatus: DelayStatus,
+) {
+    companion object {
+        fun of(order: Order) = AdminOrderResponse(
+            id = order.id,
+            userId = order.user.id,
+            adminId = order.adminId ?: 0,
+            amount = order.amount,
+            interestRate = order.interestRate,
+            term = order.term,
+            status = order.status,
+            content = order.content,
+            delayStatus = order.delayStatus,
+        )
+
+        fun of(orders: List<Order>): List<AdminOrderResponse> = orders.map { of(it) }
+    }
+}

--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/order/presentation/OrderResponse.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/order/presentation/OrderResponse.kt
@@ -11,6 +11,7 @@ data class OrderResponse(
     val interestRate: BigDecimal,
     val term: Int,
     val status: OrderStatus,
+    val content: String? = null,
     val delayStatus: DelayStatus,
 ) {
     companion object {
@@ -20,6 +21,7 @@ data class OrderResponse(
             interestRate = order.interestRate,
             term = order.term,
             status = order.status,
+            content = order.content,
             delayStatus = order.delayStatus,
         )
 

--- a/cruel-core/build.gradle.kts
+++ b/cruel-core/build.gradle.kts
@@ -9,10 +9,7 @@ tasks.getByName<Jar>("jar") {
 }
 
 plugins {
-    kotlin(Plugins.Module.jpa)
 }
 
 dependencies {
-    implementation(Dependencies.Data.jpa)
-    implementation(Dependencies.Data.jdsl)
 }

--- a/cruel-core/src/main/kotlin/io/fana/cruel/core/type/DelayStatusSearchFilter.kt
+++ b/cruel-core/src/main/kotlin/io/fana/cruel/core/type/DelayStatusSearchFilter.kt
@@ -1,0 +1,7 @@
+package io.fana.cruel.core.type
+
+enum class DelayStatusSearchFilter {
+    ALL,
+    NORMAL,
+    DELAYED;
+}

--- a/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatus.kt
+++ b/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatus.kt
@@ -4,6 +4,6 @@ enum class OrderStatus {
     CREATED,
     CANCELED,
     REJECTED,
-    ACTIVATED,
+    APPROVED,
     COMPLETED;
 }

--- a/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatusSearchFilter.kt
+++ b/cruel-core/src/main/kotlin/io/fana/cruel/core/type/OrderStatusSearchFilter.kt
@@ -1,0 +1,10 @@
+package io.fana.cruel.core.type
+
+enum class OrderStatusSearchFilter {
+    ALL,
+    CREATED,
+    CANCELED,
+    REJECTED,
+    ACTIVATED,
+    COMPLETED;
+}

--- a/cruel-domain-common/build.gradle.kts
+++ b/cruel-domain-common/build.gradle.kts
@@ -19,12 +19,6 @@ plugins {
 
 dependencies {
     implementation(project(Dependencies.Cruel.core))
-
     implementation(Dependencies.Data.jpa)
-    implementation(Dependencies.Data.jdsl)
-
-    runtimeOnly(Dependencies.Data.h2)
-    runtimeOnly(Dependencies.Data.mysqlConnector)
-
     testImplementation(Dependencies.Spring.starterTest)
 }

--- a/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/RepaymentSchedule.kt
+++ b/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/RepaymentSchedule.kt
@@ -1,0 +1,8 @@
+package io.fana.cruel.domain.repayment
+
+data class RepaymentSchedule(
+    val seqId: Int,
+    val principal: Int,
+    val interest: Int,
+    val totalAmount: Int,
+)

--- a/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/application/CalculateRepaymentService.kt
+++ b/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/application/CalculateRepaymentService.kt
@@ -1,9 +1,9 @@
 package io.fana.cruel.domain.repayment.application
 
 import io.fana.cruel.domain.repayment.RepaymentSchedule
+import org.springframework.stereotype.Service
 import kotlin.math.pow
 import kotlin.math.roundToInt
-import org.springframework.stereotype.Service
 
 @Service
 class CalculateRepaymentService {
@@ -15,16 +15,17 @@ class CalculateRepaymentService {
      * @return list of RepaymentSchedule
      * @see RepaymentSchedule
      */
-    fun calculateRepayment(
+    fun createRepaymentSchedules(
         totalPrincipal: Int,
         yearlyInterestRate: Double,
         term: Int,
     ): List<RepaymentSchedule> {
         var remainPrincipal = totalPrincipal
+        val monthlyInterestRate = yearlyInterestRate / term
         // TODO: 월 상환 원리금이 항상 같도록 보정이 필요함
         return List(term) {
             var seqId = it + 1
-            var interestAmount = (remainPrincipal * yearlyInterestRate / MONTHLY).roundToInt()
+            var interestAmount = (remainPrincipal * monthlyInterestRate).roundToInt()
             var monthlyPrincipalInterestAmount =
                 getMonthlyPrincipalInterestAmount(remainPrincipal, term - it, yearlyInterestRate)
             var principal = monthlyPrincipalInterestAmount - interestAmount
@@ -42,15 +43,14 @@ class CalculateRepaymentService {
      * 월에 납입해야 할 상환 원리금 계산
      * @param amount 잔금
      * @param term 남은 상계기간
-     * @param interestRate 연 이자율
+     * @param monthlyInterestRate 월 단위 이자율
      * @return 월 상환 원리금
      */
     private fun getMonthlyPrincipalInterestAmount(
         amount: Int,
         term: Int,
-        interestRate: Double,
+        monthlyInterestRate: Double,
     ): Int {
-        val monthlyInterestRate = interestRate / MONTHLY
         val base = (1 + monthlyInterestRate).pow(term.toDouble()) - 1
         return (amount * (monthlyInterestRate + (monthlyInterestRate / base))).roundToInt()
     }

--- a/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/application/CalculateRepaymentService.kt
+++ b/cruel-domain-common/src/main/kotlin/io/fana/cruel/domain/repayment/application/CalculateRepaymentService.kt
@@ -1,0 +1,61 @@
+package io.fana.cruel.domain.repayment.application
+
+import io.fana.cruel.domain.repayment.RepaymentSchedule
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import org.springframework.stereotype.Service
+
+@Service
+class CalculateRepaymentService {
+    /**
+     * Calculate repayment schedule, assumes no grace period
+     * @param totalPrincipal total principal of the loan
+     * @param yearlyInterestRate yearly interest rate scale 0 ~ 1
+     * @param term loan term
+     * @return list of RepaymentSchedule
+     * @see RepaymentSchedule
+     */
+    fun calculateRepayment(
+        totalPrincipal: Int,
+        yearlyInterestRate: Double,
+        term: Int,
+    ): List<RepaymentSchedule> {
+        var remainPrincipal = totalPrincipal
+        // TODO: 월 상환 원리금이 항상 같도록 보정이 필요함
+        return List(term) {
+            var seqId = it + 1
+            var interestAmount = (remainPrincipal * yearlyInterestRate / MONTHLY).roundToInt()
+            var monthlyPrincipalInterestAmount =
+                getMonthlyPrincipalInterestAmount(remainPrincipal, term - it, yearlyInterestRate)
+            var principal = monthlyPrincipalInterestAmount - interestAmount
+            remainPrincipal -= principal
+            RepaymentSchedule(
+                seqId = seqId,
+                principal = principal,
+                interest = interestAmount,
+                totalAmount = monthlyPrincipalInterestAmount,
+            )
+        }
+    }
+
+    /**
+     * 월에 납입해야 할 상환 원리금 계산
+     * @param amount 잔금
+     * @param term 남은 상계기간
+     * @param interestRate 연 이자율
+     * @return 월 상환 원리금
+     */
+    private fun getMonthlyPrincipalInterestAmount(
+        amount: Int,
+        term: Int,
+        interestRate: Double,
+    ): Int {
+        val monthlyInterestRate = interestRate / MONTHLY
+        val base = (1 + monthlyInterestRate).pow(term.toDouble()) - 1
+        return (amount * (monthlyInterestRate + (monthlyInterestRate / base))).roundToInt()
+    }
+
+    companion object {
+        private const val MONTHLY = 12
+    }
+}

--- a/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
+++ b/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
@@ -15,7 +15,7 @@ internal class CalculateRepaymentServiceTest : BehaviorSpec({
     given("총 원금, 연 이자율, 대출 기간이 주어졌을 때") {
         `when`("상환 계획을 계산하면") {
             then("상환 계획이 반환된다") {
-                val results = calculateRepaymentService.calculateRepayment(
+                val results = calculateRepaymentService.createRepaymentSchedules(
                     totalPrincipal = principals.random(),
                     yearlyInterestRate = interestRates.random(),
                     term = terms.random(),

--- a/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
+++ b/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
@@ -1,0 +1,8 @@
+package io.fana.cruel.domain.repayment
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+
+internal class CalculateRepaymentServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+})

--- a/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
+++ b/cruel-domain-common/src/test/kotlin/io/fana/cruel/domain/repayment/CalculateRepaymentServiceTest.kt
@@ -1,8 +1,29 @@
 package io.fana.cruel.domain.repayment
 
+import io.fana.cruel.domain.repayment.application.CalculateRepaymentService
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 
 internal class CalculateRepaymentServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
+
+    val calculateRepaymentService = CalculateRepaymentService()
+    val principals = listOf(500_000, 1_000_000, 1_500_000, 2_000_000)
+    val interestRates = listOf(0.05, 0.1, 0.15, 0.2)
+    val terms = listOf(3, 6, 9, 12)
+
+    given("총 원금, 연 이자율, 대출 기간이 주어졌을 때") {
+        `when`("상환 계획을 계산하면") {
+            then("상환 계획이 반환된다") {
+                val results = calculateRepaymentService.calculateRepayment(
+                    totalPrincipal = principals.random(),
+                    yearlyInterestRate = interestRates.random(),
+                    term = terms.random(),
+                )
+                for (result in results) {
+                    println(result.toString())
+                }
+            }
+        }
+    }
 })

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/admin/infra/JpaAdminRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/admin/infra/JpaAdminRepository.kt
@@ -5,7 +5,7 @@ import io.fana.cruel.domain.admin.domain.AdminRepository
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaAdminRepository : AdminRepository, JpaRepository<Admin, Long> {
-    override fun findAdminByUserId(id: Long): Admin?
+    override fun findAdminByUserId(userId: Long): Admin?
 
     override fun save(admin: Admin): Admin
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/UpdateOrderService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/UpdateOrderService.kt
@@ -1,0 +1,20 @@
+package io.fana.cruel.domain.order.application
+
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.application.CreateReturnScheduleService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+@Service
+class UpdateOrderService(
+    private val getOrderService: GetOrderService,
+    private val createReturnScheduleService: CreateReturnScheduleService,
+) {
+    fun approveOrder(orderId: Long, date: LocalDateTime): Order {
+        val order = getOrderService.getOrderById(orderId)
+        createReturnScheduleService.createReturnSchedules(order, date)
+        return order.approved()
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
@@ -93,9 +93,9 @@ class Order(
         return this
     }
 
-    fun activated(): Order {
-        requireOrderStatus(OrderStatus.CREATED, OrderStatus.ACTIVATED)
-        status = OrderStatus.ACTIVATED
+    fun approved(): Order {
+        requireOrderStatus(OrderStatus.CREATED, OrderStatus.APPROVED)
+        status = OrderStatus.APPROVED
         return this
     }
 
@@ -106,7 +106,7 @@ class Order(
     }
 
     fun completed(): Order {
-        requireOrderStatus(OrderStatus.ACTIVATED, OrderStatus.COMPLETED)
+        requireOrderStatus(OrderStatus.APPROVED, OrderStatus.COMPLETED)
         status = OrderStatus.COMPLETED
         return this
     }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/CreateReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/CreateReturnScheduleService.kt
@@ -1,0 +1,34 @@
+package io.fana.cruel.domain.schedule.application
+
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.repayment.application.CalculateRepaymentService
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.schedule.infra.JpaReturnScheduleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Transactional
+@Service
+class CreateReturnScheduleService(
+    private val calculateRepaymentService: CalculateRepaymentService,
+    private val returnScheduleRepository: JpaReturnScheduleRepository,
+) {
+    fun createReturnSchedules(order: Order, date: LocalDateTime): List<ReturnSchedule> {
+        val repaymentSchedules = calculateRepaymentService.createRepaymentSchedules(
+            order.amount,
+            order.interestRate.toDouble(),
+            order.term
+        )
+        val returnSchedules = repaymentSchedules.map {
+            ReturnSchedule(
+                orderId = order.id,
+                principal = it.principal,
+                interest = it.interest,
+                seqId = it.seqId,
+                scheduledAt = date.plusMonths(it.seqId.toLong())
+            )
+        }
+        return returnScheduleRepository.saveAll(returnSchedules)
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
@@ -14,7 +14,7 @@ import javax.persistence.Table
     indexes = [
         Index(name = "idx_return_schedules_order_id", columnList = "order_id"),
         Index(name = "idx_return_schedules_principal", columnList = "principal"),
-        Index(name = "idx_return_schedules_interest_amount", columnList = "interest_amount"),
+        Index(name = "idx_return_schedules_interest", columnList = "interest"),
         Index(name = "idx_return_schedules_scheduled_at", columnList = "scheduled_at"),
         Index(name = "idx_return_schedules_is_returned", columnList = "is_returned"),
     ]
@@ -27,11 +27,17 @@ class ReturnSchedule(
     @Column(name = "principal", nullable = false)
     val principal: Int,
 
-    @Column(name = "interest_amount", nullable = false)
-    val interestAmount: Int,
+    @Column(name = "interest", nullable = false)
+    val interest: Int,
+
+    @Column(name = "seq_id", nullable = false)
+    val seqId: Int,
 
     scheduledAt: LocalDateTime,
 ) : BaseEntity() {
+    @Column(name = "total_amount", nullable = false)
+    val totalAmount: Int = principal + interest
+
     @Column(name = "is_returned", nullable = false)
     val isReturned: Boolean = false
 

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
@@ -1,0 +1,8 @@
+package io.fana.cruel.domain.schedule.domain
+
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ReturnScheduleRepository {
+    fun save(returnSchedule: ReturnSchedule): ReturnSchedule
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
@@ -1,0 +1,11 @@
+package io.fana.cruel.domain.schedule.infra
+
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.schedule.domain.ReturnScheduleRepository
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface JpaReturnScheduleRepository : ReturnScheduleRepository, JpaRepository<ReturnSchedule, Long> {
+    override fun save(returnSchedule: ReturnSchedule): ReturnSchedule
+}

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/domain/OrderStatusTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/domain/OrderStatusTest.kt
@@ -30,7 +30,7 @@ internal class OrderStatusTest : BehaviorSpec({
             }
             given("주문이 CREATED가 아닐 때") {
                 `when`("활성화된 주문의 취소를 시도하면") {
-                    val activatedOrder = orderFixture.activated()
+                    val activatedOrder = orderFixture.approved()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
                             activatedOrder.canceled()
@@ -38,7 +38,7 @@ internal class OrderStatusTest : BehaviorSpec({
                     }
                 }
                 `when`("완료된 주문의 취소를 시도하면") {
-                    val activatedOrder = orderFixture.activated()
+                    val activatedOrder = orderFixture.approved()
                     val completedOrder = activatedOrder.completed()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
@@ -55,7 +55,7 @@ internal class OrderStatusTest : BehaviorSpec({
             }
             given("주문이 CREATED가 아닐 때") {
                 `when`("활성화된 주문의 거절을 시도하면") {
-                    val activatedOrder = orderFixture.activated()
+                    val activatedOrder = orderFixture.approved()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
                             activatedOrder.rejected()
@@ -63,7 +63,7 @@ internal class OrderStatusTest : BehaviorSpec({
                     }
                 }
                 `when`("완료된 주문의 거절을 시도하면") {
-                    val activatedOrder = orderFixture.activated()
+                    val activatedOrder = orderFixture.approved()
                     val completedOrder = activatedOrder.completed()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
@@ -75,31 +75,31 @@ internal class OrderStatusTest : BehaviorSpec({
         }
         `when`("주문을 활성화하면") {
             then("주문이 활성화된다") {
-                orderFixture.activated()
-                orderFixture.status shouldBe OrderStatus.ACTIVATED
+                orderFixture.approved()
+                orderFixture.status shouldBe OrderStatus.APPROVED
             }
             given("주문이 CREATED가 아닐 때") {
                 `when`("취소된 주문의 활성화를 시도하면") {
                     val canceledOrder = orderFixture.canceled()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
-                            canceledOrder.activated()
+                            canceledOrder.approved()
                         }
                     }
                 }
                 `when`("완료된 주문의 활성화를 시도하면") {
-                    val activatedOrder = orderFixture.activated()
+                    val activatedOrder = orderFixture.approved()
                     val completedOrder = activatedOrder.completed()
                     then("예외가 발생한다") {
                         shouldThrow<InvalidOrderStatusException> {
-                            completedOrder.activated()
+                            completedOrder.approved()
                         }
                     }
                 }
             }
         }
         `when`("주문을 완료하면") {
-            val activatedOrder = orderFixture.activated()
+            val activatedOrder = orderFixture.approved()
             then("주문이 완료된다") {
                 println(activatedOrder.status)
                 activatedOrder.completed()


### PR DESCRIPTION
* ISSUE: [ISSUE-9](https://github.com/chunghwanyoon/cruel/issues/9)
* ISSUE: [ISSUE-10](https://github.com/chunghwanyoon/cruel/issues/10)

## 변경 사항
- 주문 관리 API(승인) 추가
- 상환 스케쥴 계산 도메인 추가

## 체크 리스트
- [ ] 정상 동작 확인
- [ ] 테스트 작성
- [ ] 주석 및 문서 수정
