### PR TITLE
[ISSUE-12] 어드민 주문 관리 API 추가

### DIFF
--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderController.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderController.kt
@@ -2,10 +2,16 @@ package io.fana.cruel.app.v1.admin.order.presentation
 
 import io.fana.cruel.core.type.DelayStatusSearchFilter
 import io.fana.cruel.core.type.OrderStatusSearchFilter
+import io.fana.cruel.domain.order.application.DeleteOrderService
+import io.fana.cruel.domain.order.application.GetOrderService
 import io.fana.cruel.domain.order.application.UpdateOrderService
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,20 +23,43 @@ import java.time.LocalDateTime
 @RestController
 @RequestMapping("/api/v1/admin/orders")
 class AdminOrderController(
+    private val getOrderService: GetOrderService,
     private val updateOrderService: UpdateOrderService,
+    private val deleteOrderService: DeleteOrderService,
 ) {
-    fun getOrders(
+    @Operation(summary = "getAdminOrders", description = "어드민 주문 목록 조회")
+    @ApiResponse(description = "조회 성공", responseCode = "200")
+    @GetMapping
+    fun getAdminOrders(
         @RequestParam(defaultValue = "ALL") statusFilter: OrderStatusSearchFilter,
         @RequestParam(defaultValue = "ALL") delayedFilter: DelayStatusSearchFilter,
+        @RequestParam(defaultValue = Long.MAX_VALUE.toString()) lastSeen: Long,
+        @RequestParam(defaultValue = "20") limit: Int,
     ): List<AdminOrderResponse> {
-        TODO()
+        return AdminOrderResponse.of(
+            getOrderService.getOrders(
+                statusFilter = statusFilter,
+                delayedFilter = delayedFilter,
+                lastSeen = lastSeen,
+                limit = limit,
+            )
+        )
     }
 
     @PostMapping("/{orderId}/approve")
+    @Operation(summary = "approveOrder", description = "어드민 주문 승인")
+    @ApiResponse(description = "요청 성공", responseCode = "201")
     fun approveOrder(
         @Parameter(name = "orderId", `in` = ParameterIn.PATH, description = "주문 ID")
         @PathVariable("orderId") orderId: Long,
     ): AdminOrderResponse {
         return AdminOrderResponse.of(updateOrderService.approveOrder(orderId, LocalDateTime.now()))
     }
+
+    @DeleteMapping("/{orderId}")
+    @Operation(summary = "rejectOrder", description = "어드민 주문 거절")
+    @ApiResponse(description = "요청 성공", responseCode = "204")
+    fun rejectOrder(
+        @PathVariable("orderId") orderId: Long,
+    ) = deleteOrderService.rejectOrder(orderId)
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/config/JpaConfig.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/config/JpaConfig.kt
@@ -1,0 +1,16 @@
+package io.fana.cruel.domain.config
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@Configuration
+@EnableJpaAuditing
+@EntityScan(basePackages = ["io.fana.cruel.domain"])
+@EnableJpaRepositories(
+    basePackages = ["io.fana.cruel.domain"],
+    repositoryFactoryBeanClass = EnversRevisionRepositoryFactoryBean::class
+)
+class JpaConfig

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/config/KotlinJdslConfig.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/config/KotlinJdslConfig.kt
@@ -1,0 +1,20 @@
+package io.fana.cruel.domain.config
+
+import com.linecorp.kotlinjdsl.QueryFactoryImpl
+import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreatorImpl
+import com.linecorp.kotlinjdsl.query.creator.SubqueryCreatorImpl
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class KotlinJdslConfig(
+    @PersistenceContext val entityManager: EntityManager,
+) {
+    @Bean
+    fun jpaQueryFactory() = QueryFactoryImpl(
+        criteriaQueryCreator = CriteriaQueryCreatorImpl(entityManager),
+        subqueryCreator = SubqueryCreatorImpl(),
+    )
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/DeleteOrderService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/DeleteOrderService.kt
@@ -1,0 +1,18 @@
+package io.fana.cruel.domain.order.application
+
+import io.fana.cruel.domain.schedule.application.DeleteReturnScheduleService
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+@Transactional
+@Service
+class DeleteOrderService(
+    private val getOrderService: GetOrderService,
+    private val deleteReturnScheduleService: DeleteReturnScheduleService,
+) {
+    fun rejectOrder(orderId: Long) {
+        val order = getOrderService.getOrderById(orderId)
+        order.rejected()
+        deleteReturnScheduleService.deleteReturnSchedulesByOrderId(order.id)
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/GetOrderService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/GetOrderService.kt
@@ -1,6 +1,9 @@
 package io.fana.cruel.domain.order.application
 
+import io.fana.cruel.core.type.DelayStatusSearchFilter
+import io.fana.cruel.core.type.OrderStatusSearchFilter
 import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.order.domain.OrderQueryRepository
 import io.fana.cruel.domain.order.domain.OrderRepository
 import io.fana.cruel.domain.order.exception.OrderNotFoundException
 import org.springframework.stereotype.Service
@@ -10,7 +13,22 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GetOrderService(
     private val orderRepository: OrderRepository,
+    private val orderQueryRepository: OrderQueryRepository,
 ) {
+    fun getOrders(
+        statusFilter: OrderStatusSearchFilter,
+        delayedFilter: DelayStatusSearchFilter,
+        lastSeen: Long,
+        limit: Int,
+    ): List<Order> {
+        return orderQueryRepository.findOrderByStatusAndDelayStatusFilters(
+            statusFilter,
+            delayedFilter,
+            lastSeen,
+            limit,
+        )
+    }
+
     fun getOrdersByUserId(userId: Long): List<Order> = orderRepository.findAllByUserId(userId)
 
     fun getOrderById(orderId: Long): Order = orderRepository.findOrderById(orderId)

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/OrderQueryRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/OrderQueryRepository.kt
@@ -1,0 +1,13 @@
+package io.fana.cruel.domain.order.domain
+
+import io.fana.cruel.core.type.DelayStatusSearchFilter
+import io.fana.cruel.core.type.OrderStatusSearchFilter
+
+interface OrderQueryRepository {
+    fun findOrderByStatusAndDelayStatusFilters(
+        statusFilter: OrderStatusSearchFilter,
+        delayedFilter: DelayStatusSearchFilter,
+        lastSeen: Long,
+        limit: Int,
+    ): List<Order>
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/infra/KotlinJdslOrderQueryRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/infra/KotlinJdslOrderQueryRepository.kt
@@ -1,0 +1,65 @@
+package io.fana.cruel.domain.order.infra
+
+import com.linecorp.kotlinjdsl.QueryFactory
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
+import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import io.fana.cruel.core.type.DelayStatus
+import io.fana.cruel.core.type.DelayStatusSearchFilter
+import io.fana.cruel.core.type.OrderStatus
+import io.fana.cruel.core.type.OrderStatusSearchFilter
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.order.domain.OrderQueryRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class KotlinJdslOrderQueryRepository(
+    private val queryFactory: QueryFactory,
+) : OrderQueryRepository {
+    override fun findOrderByStatusAndDelayStatusFilters(
+        statusFilter: OrderStatusSearchFilter,
+        delayedFilter: DelayStatusSearchFilter,
+        lastSeen: Long,
+        limit: Int,
+    ): List<Order> {
+        return queryFactory.listQuery {
+            select(entity(Order::class))
+            from(entity(Order::class))
+            where(
+                and(
+                    filterBy(statusFilter, delayedFilter),
+                    col(Order::id).lessThan(lastSeen),
+                )
+            )
+            orderBy(col(Order::id).desc())
+            limit(limit)
+        }
+    }
+
+    private fun <T> CriteriaQueryDsl<T>.filterBy(
+        statusFilter: OrderStatusSearchFilter,
+        delayedFilter: DelayStatusSearchFilter,
+    ): PredicateSpec {
+        val delayQuery = when (delayedFilter) {
+            DelayStatusSearchFilter.NORMAL -> and(col(Order::delayStatus).equal(DelayStatus.NORMAL))
+            DelayStatusSearchFilter.DELAYED -> and(col(Order::delayStatus).equal(DelayStatus.DELAYED))
+            DelayStatusSearchFilter.ALL -> or(
+                col(Order::delayStatus).equal(DelayStatus.NORMAL),
+                col(Order::delayStatus).equal(DelayStatus.DELAYED),
+            )
+        }
+        val statusQuery = when (statusFilter) {
+            OrderStatusSearchFilter.ALL -> or(
+                col(Order::status).equal(OrderStatus.CREATED),
+                col(Order::status).equal(OrderStatus.CANCELED),
+                col(Order::status).equal(OrderStatus.COMPLETED),
+                col(Order::status).equal(OrderStatus.REJECTED),
+                col(Order::status).equal(OrderStatus.APPROVED),
+            )
+
+            else -> and(col(Order::status).equal(OrderStatus.valueOf(statusFilter.name)))
+        }
+        return and(delayQuery, statusQuery)
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/CreateReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/CreateReturnScheduleService.kt
@@ -1,6 +1,7 @@
 package io.fana.cruel.domain.schedule.application
 
 import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.repayment.RepaymentSchedule
 import io.fana.cruel.domain.repayment.application.CalculateRepaymentService
 import io.fana.cruel.domain.schedule.domain.ReturnSchedule
 import io.fana.cruel.domain.schedule.infra.JpaReturnScheduleRepository
@@ -20,13 +21,21 @@ class CreateReturnScheduleService(
             order.interestRate.toDouble(),
             order.term
         )
+        return createReturnSchedulesByRepaymentSchedules(order.id, repaymentSchedules, date)
+    }
+
+    private fun createReturnSchedulesByRepaymentSchedules(
+        orderId: Long,
+        repaymentSchedules: List<RepaymentSchedule>,
+        date: LocalDateTime,
+    ): List<ReturnSchedule> {
         val returnSchedules = repaymentSchedules.map {
             ReturnSchedule(
-                orderId = order.id,
+                orderId = orderId,
                 principal = it.principal,
                 interest = it.interest,
                 seqId = it.seqId,
-                scheduledAt = date.plusMonths(it.seqId.toLong())
+                scheduledAt = date.plusMonths(it.seqId.toLong()),
             )
         }
         return returnScheduleRepository.saveAll(returnSchedules)

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/DeleteReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/DeleteReturnScheduleService.kt
@@ -1,0 +1,17 @@
+package io.fana.cruel.domain.schedule.application
+
+import io.fana.cruel.domain.schedule.infra.JpaReturnScheduleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class DeleteReturnScheduleService(
+    private val returnScheduleRepository: JpaReturnScheduleRepository,
+    private val getReturnScheduleService: GetReturnScheduleService,
+) {
+    fun deleteReturnSchedulesByOrderId(orderId: Long) {
+        val returnSchedules = getReturnScheduleService.getReturnSchedulesByOrderId(orderId)
+        returnScheduleRepository.deleteAll(returnSchedules)
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
@@ -1,0 +1,16 @@
+package io.fana.cruel.domain.schedule.application
+
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.schedule.domain.ReturnScheduleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class GetReturnScheduleService(
+    private val returnScheduleRepository: ReturnScheduleRepository,
+) {
+    fun getReturnSchedulesByOrderId(orderId: Long): List<ReturnSchedule> {
+        return returnScheduleRepository.getAllByOrderId(orderId)
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
@@ -4,5 +4,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface ReturnScheduleRepository {
+    fun getAllByOrderId(orderId: Long): List<ReturnSchedule>
+
     fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
@@ -7,5 +7,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface JpaReturnScheduleRepository : ReturnScheduleRepository, JpaRepository<ReturnSchedule, Long> {
+    override fun getAllByOrderId(orderId: Long): List<ReturnSchedule>
+
     override fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/DeleteOrderServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/DeleteOrderServiceTest.kt
@@ -1,0 +1,38 @@
+package io.fana.cruel.domain.order.application
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.fana.cruel.domain.order.OrderTerm
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.application.DeleteReturnScheduleService
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+
+internal class DeleteOrderServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+    val getOrderService = mockk<GetOrderService>()
+    val deleteReturnScheduleService = mockk<DeleteReturnScheduleService>()
+    val deleteOrderService = DeleteOrderService(
+        getOrderService = getOrderService,
+        deleteReturnScheduleService = deleteReturnScheduleService,
+    )
+    val orderFixture = fixture<Order> {
+        factory<OrderTerm> { OrderTerm(3) }
+    }
+
+    given("주문이 주어졌을 때") {
+        every { getOrderService.getOrderById(orderFixture.id) } returns orderFixture
+        every { deleteReturnScheduleService.deleteReturnSchedulesByOrderId(orderFixture.id) } returns Unit
+
+        `when`("주문을 거절하면") {
+            then("주문이 거절되고, 상환 스케쥴이 삭제된다") {
+                shouldNotThrowAny {
+                    deleteOrderService.rejectOrder(orderFixture.id)
+                }
+            }
+        }
+    }
+})

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/DeleteReturnScheduleServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/DeleteReturnScheduleServiceTest.kt
@@ -1,0 +1,44 @@
+package io.fana.cruel.domain.order.application
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.fana.cruel.domain.order.OrderTerm
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.application.DeleteReturnScheduleService
+import io.fana.cruel.domain.schedule.application.GetReturnScheduleService
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.schedule.infra.JpaReturnScheduleRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+
+internal class DeleteReturnScheduleServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+    val returnScheduleRepository = mockk<JpaReturnScheduleRepository>()
+    val getReturnScheduleService = mockk<GetReturnScheduleService>()
+    val deleteReturnScheduleService = DeleteReturnScheduleService(
+        returnScheduleRepository = returnScheduleRepository,
+        getReturnScheduleService = getReturnScheduleService,
+    )
+    val orderFixture = fixture<Order> {
+        factory<OrderTerm> { OrderTerm(12) }
+    }
+    val returnScheduleFixtures = fixture<List<ReturnSchedule>> {
+        property(ReturnSchedule::orderId) { orderFixture.id }
+    }
+
+    given("주문이 주어졌을 때") {
+        every { getReturnScheduleService.getReturnSchedulesByOrderId(orderFixture.id) } returns returnScheduleFixtures
+        every { returnScheduleRepository.deleteAll(returnScheduleFixtures) } returns Unit
+
+        `when`("상환 스케쥴을 삭제하면") {
+            then("해당 주문의 상환 스케쥴이 삭제된다") {
+                shouldNotThrowAny {
+                    deleteReturnScheduleService.deleteReturnSchedulesByOrderId(orderFixture.id)
+                }
+            }
+        }
+    }
+})

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/UpdateOrderServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/UpdateOrderServiceTest.kt
@@ -1,0 +1,45 @@
+package io.fana.cruel.domain.order.application
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.fana.cruel.core.type.OrderStatus
+import io.fana.cruel.domain.order.OrderTerm
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.application.CreateReturnScheduleService
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+internal class UpdateOrderServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+    val getOrderService = mockk<GetOrderService>()
+    val createReturnScheduleService = mockk<CreateReturnScheduleService>()
+    val updateOrderService = UpdateOrderService(
+        getOrderService = getOrderService,
+        createReturnScheduleService = createReturnScheduleService,
+    )
+    val now = LocalDateTime.now()
+    val orderFixture = fixture<Order> {
+        factory<OrderTerm> { OrderTerm(12) }
+    }
+    val returnScheduleFixtures = fixture<List<ReturnSchedule>> {
+        property(ReturnSchedule::orderId) { orderFixture.id }
+    }
+
+    given("주문이 주어졌을 때") {
+        every { getOrderService.getOrderById(orderFixture.id) } returns orderFixture
+        every { createReturnScheduleService.createReturnSchedules(orderFixture, now) } returns returnScheduleFixtures
+
+        `when`("주문을 승인 처리하면") {
+            then("주문이 승인되고 상환 스케쥴이 생성된다") {
+                val order = updateOrderService.approveOrder(orderFixture.id, now)
+
+                order.status shouldBe OrderStatus.APPROVED
+            }
+        }
+    }
+})


### PR DESCRIPTION
* ISSUE: [ISSUE-12](https://github.com/chunghwanyoon/cruel/issues/12)

## 변경 사항
- 어드민 주문 조회 by 상태 필터, 연체 필터 + 페이지네이션
- 주문 승인
- 주문 거절

## 체크 리스트
- [ ] 정상 동작 확인
- [ ] 테스트 작성
- [ ] 주석 및 문서 수정
