### PR TITLE
[ISSUE-14] 유저의 주문별 상환 스케쥴 조회, 상환 처리, 다가올 상환 일정 확인 API 구현

### DIFF
--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/RepaymentController.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/RepaymentController.kt
@@ -1,0 +1,56 @@
+package io.fana.cruel.app.v1.schedule.presentation
+
+import io.fana.cruel.app.security.LoginUser
+import io.fana.cruel.domain.schedule.application.GetReturnScheduleService
+import io.fana.cruel.domain.schedule.application.SummarizedRepaymentInformation
+import io.fana.cruel.domain.schedule.application.UpdateReturnScheduleService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "상환 API", description = "Repayment API")
+@RestController
+@RequestMapping("/api/v1/repayments")
+class RepaymentController(
+    private val getReturnScheduleService: GetReturnScheduleService,
+    private val updateReturnScheduleService: UpdateReturnScheduleService,
+) {
+    @GetMapping
+    @Operation(operationId = "getRepaymentSchedules", description = "상환 스케줄 조회")
+    @ApiResponse(description = "조회 성공", responseCode = "200")
+    fun getRepaymentSchedules(
+        @RequestParam("orderId") orderId: Long,
+        @Parameter(hidden = true)
+        loginUser: LoginUser,
+    ): List<ReturnScheduleResponse> {
+        return ReturnScheduleResponse.of(getReturnScheduleService.getReturnSchedulesByOrderId(orderId))
+    }
+
+    @GetMapping("/summarized-info")
+    @Operation(operationId = "getSummarizeRepaymentInfo", description = "다가오는 상환 정보 조회")
+    @ApiResponse(description = "조회 성공", responseCode = "200")
+    fun getSummarizeRepaymentInfo(
+        @Parameter(hidden = true)
+        loginUser: LoginUser,
+    ): SummarizedRepaymentInformation {
+        return getReturnScheduleService.getSummarizedReturnInformation(loginUser.id)
+    }
+
+    @PostMapping("/{scheduleId}")
+    @Operation(operationId = "repay", description = "상환")
+    @ApiResponse(description = "요청 성공", responseCode = "201")
+    fun repay(
+        @Parameter(hidden = true)
+        loginUser: LoginUser,
+        @PathVariable("scheduleId") scheduleId: Long,
+    ): ReturnScheduleResponse {
+        return ReturnScheduleResponse.of(updateReturnScheduleService.repayReturnSchedule(scheduleId))
+    }
+}

--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/RepaymentController.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/RepaymentController.kt
@@ -39,7 +39,7 @@ class RepaymentController(
     fun getSummarizeRepaymentInfo(
         @Parameter(hidden = true)
         loginUser: LoginUser,
-    ): SummarizedRepaymentInformation {
+    ): List<SummarizedRepaymentInformation> {
         return getReturnScheduleService.getSummarizedReturnInformation(loginUser.id)
     }
 

--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/ReturnScheduleResponse.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/schedule/presentation/ReturnScheduleResponse.kt
@@ -1,0 +1,30 @@
+package io.fana.cruel.app.v1.schedule.presentation
+
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import java.time.LocalDateTime
+
+data class ReturnScheduleResponse(
+    val orderId: Long,
+    val seqId: Int,
+    val principal: Int,
+    val interest: Int,
+    val totalAmount: Int,
+    val isReturned: Boolean,
+    val scheduledAt: LocalDateTime,
+    val returnedAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(returnSchedule: ReturnSchedule) = ReturnScheduleResponse(
+            orderId = returnSchedule.orderId,
+            seqId = returnSchedule.seqId,
+            principal = returnSchedule.principal,
+            interest = returnSchedule.interest,
+            totalAmount = returnSchedule.totalAmount,
+            isReturned = returnSchedule.isReturned,
+            scheduledAt = returnSchedule.scheduledAt,
+            returnedAt = returnSchedule.returnedAt,
+        )
+
+        fun of(returnSchedules: List<ReturnSchedule>) = returnSchedules.map { of(it) }
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
@@ -2,6 +2,7 @@ package io.fana.cruel.domain.schedule.application
 
 import io.fana.cruel.domain.schedule.domain.ReturnSchedule
 import io.fana.cruel.domain.schedule.domain.ReturnScheduleRepository
+import io.fana.cruel.domain.user.application.GetUserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -9,8 +10,18 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GetReturnScheduleService(
     private val returnScheduleRepository: ReturnScheduleRepository,
+    private val getUserService: GetUserService,
 ) {
     fun getReturnSchedulesByOrderId(orderId: Long): List<ReturnSchedule> {
         return returnScheduleRepository.getAllByOrderId(orderId)
+    }
+
+    fun getReturnScheduleById(scheduleId: Long): ReturnSchedule {
+        return returnScheduleRepository.getReturnScheduleById(scheduleId)
+    }
+
+    fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation {
+        val user = getUserService.getUserById(userId)
+        return returnScheduleRepository.getSummarizedReturnInformation(user.id)
     }
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleService.kt
@@ -20,7 +20,7 @@ class GetReturnScheduleService(
         return returnScheduleRepository.getReturnScheduleById(scheduleId)
     }
 
-    fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation {
+    fun getSummarizedReturnInformation(userId: Long): List<SummarizedRepaymentInformation> {
         val user = getUserService.getUserById(userId)
         return returnScheduleRepository.getSummarizedReturnInformation(user.id)
     }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/SummarizedRepaymentInformation.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/SummarizedRepaymentInformation.kt
@@ -1,0 +1,10 @@
+package io.fana.cruel.domain.schedule.application
+
+import java.time.LocalDateTime
+
+data class SummarizedRepaymentInformation(
+    val totalPrincipal: Int,
+    val totalInterest: Int,
+    val totalAmount: Int = totalPrincipal + totalInterest,
+    val scheduledAt: LocalDateTime,
+)

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/UpdateReturnScheduleService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/application/UpdateReturnScheduleService.kt
@@ -1,0 +1,17 @@
+package io.fana.cruel.domain.schedule.application
+
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class UpdateReturnScheduleService(
+    private val getReturnScheduleService: GetReturnScheduleService,
+) {
+    fun repayReturnSchedule(scheduleId: Long): ReturnSchedule {
+        val returnSchedule = getReturnScheduleService.getReturnScheduleById(scheduleId)
+        returnSchedule.repay()
+        return returnSchedule
+    }
+}

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
@@ -1,13 +1,13 @@
 package io.fana.cruel.domain.schedule.domain
 
 import io.fana.cruel.domain.base.BaseEntity
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Index
 import javax.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
 
 @Table(
     name = "return_schedules",
@@ -39,10 +39,13 @@ class ReturnSchedule(
     val totalAmount: Int = principal + interest
 
     @Column(name = "is_returned", nullable = false)
-    val isReturned: Boolean = false
+    var isReturned: Boolean = false
 
     @Column(name = "scheduled_at", nullable = false)
     var scheduledAt: LocalDateTime = scheduledAt
+
+    @Column(name = "returned_at", nullable = false)
+    var returnedAt: LocalDateTime? = null
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)
@@ -53,4 +56,17 @@ class ReturnSchedule(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.MIN
         private set
+
+    fun repay() {
+        /**
+         * TODO:
+         * 상환 처리에 대한 도메인 규칙 필요
+         * 예시)
+         * 1. 같은 주문에 속해있는 이전 상환스케쥴이 상환되지 않았다면 상환 불가하다든지
+         * 2. 상환기일 이전 며칠내에만 상환 처리가 가능하다든지(과도한 조기상환 금지)
+         * 등등..
+         */
+        this.isReturned = true
+        returnedAt = LocalDateTime.now()
+    }
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnSchedule.kt
@@ -1,13 +1,13 @@
 package io.fana.cruel.domain.schedule.domain
 
 import io.fana.cruel.domain.base.BaseEntity
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
 import java.time.LocalDateTime
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Index
 import javax.persistence.Table
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
 
 @Table(
     name = "return_schedules",

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
@@ -1,10 +1,15 @@
 package io.fana.cruel.domain.schedule.domain
 
+import io.fana.cruel.domain.schedule.application.SummarizedRepaymentInformation
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ReturnScheduleRepository {
     fun getAllByOrderId(orderId: Long): List<ReturnSchedule>
+
+    fun getReturnScheduleById(scheduleId: Long): ReturnSchedule
+
+    fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation
 
     fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/domain/ReturnScheduleRepository.kt
@@ -9,7 +9,7 @@ interface ReturnScheduleRepository {
 
     fun getReturnScheduleById(scheduleId: Long): ReturnSchedule
 
-    fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation
+    fun getSummarizedReturnInformation(userId: Long): List<SummarizedRepaymentInformation>
 
     fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
@@ -27,7 +27,7 @@ interface JpaReturnScheduleRepository : ReturnScheduleRepository, JpaRepository<
         """,
         nativeQuery = true
     )
-    override fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation
+    override fun getSummarizedReturnInformation(userId: Long): List<SummarizedRepaymentInformation>
 
     override fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/schedule/infra/JpaReturnScheduleRepository.kt
@@ -1,13 +1,33 @@
 package io.fana.cruel.domain.schedule.infra
 
+import io.fana.cruel.domain.schedule.application.SummarizedRepaymentInformation
 import io.fana.cruel.domain.schedule.domain.ReturnSchedule
 import io.fana.cruel.domain.schedule.domain.ReturnScheduleRepository
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface JpaReturnScheduleRepository : ReturnScheduleRepository, JpaRepository<ReturnSchedule, Long> {
     override fun getAllByOrderId(orderId: Long): List<ReturnSchedule>
+
+    override fun getReturnScheduleById(scheduleId: Long): ReturnSchedule
+
+    @Query(
+        """
+            SELECT
+                SUM(`rs`.`principal`) AS `totalPrincipal`,
+                SUM(`rs`.`interest`) AS `totalInterest`,
+                SUM(`rs`.`principal`) + SUM(`rs`.`interest`) AS `totalAmount`,
+            FROM return_schedules `rs`
+            INNER JOIN orders `o` ON `o`.`id` = `rs`.`order_id`
+            WHERE `o`.`user_id` = :userId
+            AND `rs`.`is_returned` = FALSE
+            GROUP BY `rs`.`scheduled_at`
+        """,
+        nativeQuery = true
+    )
+    override fun getSummarizedReturnInformation(userId: Long): SummarizedRepaymentInformation
 
     override fun save(returnSchedule: ReturnSchedule): ReturnSchedule
 }

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleServiceTest.kt
@@ -1,0 +1,70 @@
+package io.fana.cruel.domain.schedule.application
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.fana.cruel.domain.order.OrderTerm
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.schedule.domain.ReturnScheduleRepository
+import io.fana.cruel.domain.user.application.GetUserService
+import io.fana.cruel.domain.user.domain.User
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+internal class GetReturnScheduleServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+    val returnScheduleRepository = mockk<ReturnScheduleRepository>()
+    val getUserService = mockk<GetUserService>()
+    val getReturnScheduleService = GetReturnScheduleService(
+        returnScheduleRepository = returnScheduleRepository,
+        getUserService = getUserService,
+    )
+    val userFixture = fixture<User>()
+    val orderFixture = fixture<Order> {
+        factory<OrderTerm> { OrderTerm(12) }
+        property(Order::user) { userFixture }
+    }
+    val returnScheduleFixtures = fixture<List<ReturnSchedule>> {
+        property(ReturnSchedule::orderId) { orderFixture.id }
+    }
+    val summarizedInformation = fixture<SummarizedRepaymentInformation>()
+
+    given("주문이 주어졌을 때") {
+        every { returnScheduleRepository.getAllByOrderId(orderFixture.id) } returns returnScheduleFixtures
+
+        `when`("해당 주문의 상환 스케쥴을 조회하려고 하면") {
+            then("상환 스케쥴이 조회된다") {
+                val schedules = getReturnScheduleService.getReturnSchedulesByOrderId(orderFixture.id)
+                schedules.last().orderId shouldBe orderFixture.id
+            }
+        }
+    }
+    given("상환 스케쥴이 주어졌을 때") {
+        every {
+            returnScheduleRepository.getReturnScheduleById(returnScheduleFixtures.last().id)
+        } returns returnScheduleFixtures.last()
+
+        `when`("상환 스케쥴을 조회하면") {
+            then("스케쥴이 조회된다") {
+                val schedule = getReturnScheduleService.getReturnScheduleById(returnScheduleFixtures.last().id)
+                schedule.id shouldBe returnScheduleFixtures.last().id
+            }
+        }
+    }
+    given("유저가 주어졌을 때") {
+        every { getUserService.getUserById(userFixture.id) } returns userFixture
+        every { returnScheduleRepository.getSummarizedReturnInformation(userFixture.id) } returns summarizedInformation
+
+        `when`("해당 유저의 요약된 상환스 정보를 조회하면") {
+            then("정보가 조회된다") {
+                shouldNotThrowAny {
+                    getReturnScheduleService.getSummarizedReturnInformation(userFixture.id)
+                }
+            }
+        }
+    }
+})

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/GetReturnScheduleServiceTest.kt
@@ -31,7 +31,7 @@ internal class GetReturnScheduleServiceTest : BehaviorSpec({
     val returnScheduleFixtures = fixture<List<ReturnSchedule>> {
         property(ReturnSchedule::orderId) { orderFixture.id }
     }
-    val summarizedInformation = fixture<SummarizedRepaymentInformation>()
+    val summarizedInformation = fixture<List<SummarizedRepaymentInformation>>()
 
     given("주문이 주어졌을 때") {
         every { returnScheduleRepository.getAllByOrderId(orderFixture.id) } returns returnScheduleFixtures

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/UpdateReturnScheduleServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/schedule/application/UpdateReturnScheduleServiceTest.kt
@@ -1,0 +1,44 @@
+package io.fana.cruel.domain.schedule.application
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.fana.cruel.domain.order.OrderTerm
+import io.fana.cruel.domain.order.domain.Order
+import io.fana.cruel.domain.schedule.domain.ReturnSchedule
+import io.fana.cruel.domain.user.domain.User
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+internal class UpdateReturnScheduleServiceTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+    val getReturnScheduleService = mockk<GetReturnScheduleService>()
+    val updateReturnScheduleService = UpdateReturnScheduleService(
+        getReturnScheduleService = getReturnScheduleService,
+    )
+    val userFixture = fixture<User>()
+    val orderFixture = fixture<Order> {
+        factory<OrderTerm> { OrderTerm(12) }
+        property(Order::user) { userFixture }
+    }
+    val returnScheduleFixture = fixture<ReturnSchedule> {
+        property(ReturnSchedule::orderId) { orderFixture.id }
+    }
+
+    given("상환 스케쥴이 주어졌을 때") {
+        every {
+            getReturnScheduleService.getReturnScheduleById(returnScheduleFixture.id)
+        } returns returnScheduleFixture
+
+        `when`("상환처리를 하면") {
+            then("상환처리가 완료된다") {
+                updateReturnScheduleService.repayReturnSchedule(returnScheduleFixture.id)
+
+                returnScheduleFixture.id shouldBe returnScheduleFixture.id
+                returnScheduleFixture.isReturned shouldBe true
+            }
+        }
+    }
+})


### PR DESCRIPTION
* ISSUE: [ISSUE-14](https://github.com/chunghwanyoon/cruel/issues/14)

## 변경 사항
- 유저의 주문별 상환 스케쥴 조회
- 단건 상환스케쥴 상환처리
- 다가올 상환 일정 확인

## 체크 리스트
- [ ] 정상 동작 확인
- [ ] 테스트 작성
- [ ] 주석 및 문서 수정
