### PR TITLE
[ISSUE-25] 주문을 상품 단위로 할 수 있도록 변경 및 관계 추가

### DIFF
--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderResponse.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/admin/order/presentation/AdminOrderResponse.kt
@@ -1,5 +1,6 @@
 package io.fana.cruel.app.v1.admin.order.presentation
 
+import io.fana.cruel.app.v1.product.presentation.ProductResponse
 import io.fana.cruel.core.type.DelayStatus
 import io.fana.cruel.core.type.OrderStatus
 import io.fana.cruel.domain.order.domain.Order
@@ -8,6 +9,7 @@ import java.math.BigDecimal
 data class AdminOrderResponse(
     val id: Long,
     val userId: Long,
+    val product: ProductResponse,
     val adminId: Long,
     val amount: Int,
     val interestRate: BigDecimal,
@@ -20,6 +22,7 @@ data class AdminOrderResponse(
         fun of(order: Order) = AdminOrderResponse(
             id = order.id,
             userId = order.user.id,
+            product = ProductResponse.of(order.product),
             adminId = order.adminId ?: 0,
             amount = order.amount,
             interestRate = order.interestRate,

--- a/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/order/presentation/OrderResponse.kt
+++ b/cruel-app-web/src/main/kotlin/io/fana/cruel/app/v1/order/presentation/OrderResponse.kt
@@ -1,5 +1,6 @@
 package io.fana.cruel.app.v1.order.presentation
 
+import io.fana.cruel.app.v1.product.presentation.ProductResponse
 import io.fana.cruel.core.type.DelayStatus
 import io.fana.cruel.core.type.OrderStatus
 import io.fana.cruel.domain.order.domain.Order
@@ -8,6 +9,7 @@ import java.math.BigDecimal
 data class OrderResponse(
     val id: Long,
     val amount: Int,
+    val product: ProductResponse,
     val interestRate: BigDecimal,
     val term: Int,
     val status: OrderStatus,
@@ -18,6 +20,7 @@ data class OrderResponse(
         fun of(order: Order) = OrderResponse(
             id = order.id,
             amount = order.amount,
+            product = ProductResponse.of(order.product),
             interestRate = order.interestRate,
             term = order.term,
             status = order.status,

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderRequest.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderRequest.kt
@@ -3,7 +3,6 @@ package io.fana.cruel.domain.order.application
 data class CreateOrderRequest(
     val productId: Long,
     val userId: Long,
-    val amount: Int,
     val term: Int,
     val content: String,
 )

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderRequest.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderRequest.kt
@@ -1,6 +1,7 @@
 package io.fana.cruel.domain.order.application
 
 data class CreateOrderRequest(
+    val productId: Long,
     val userId: Long,
     val amount: Int,
     val term: Int,

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderService.kt
@@ -22,7 +22,7 @@ class CreateOrderService(
         val order = Order(
             user = user,
             product = product,
-            amount = request.amount,
+            amount = product.price,
             interestRate = generateOrderInterestRate(),
             orderTerm = OrderTerm(request.term),
             content = request.content,

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderService.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/application/CreateOrderService.kt
@@ -4,6 +4,7 @@ import io.fana.cruel.domain.order.domain.Order
 import io.fana.cruel.domain.order.domain.OrderInterestRate
 import io.fana.cruel.domain.order.domain.OrderRepository
 import io.fana.cruel.domain.order.domain.OrderTerm
+import io.fana.cruel.domain.product.application.GetProductService
 import io.fana.cruel.domain.user.application.GetUserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,15 +14,18 @@ import org.springframework.transaction.annotation.Transactional
 class CreateOrderService(
     private val orderRepository: OrderRepository,
     private val getUserService: GetUserService,
+    private val getProductService: GetProductService,
 ) {
     fun requestOrder(request: CreateOrderRequest): Order {
         val user = getUserService.getUserById(request.userId)
+        val product = getProductService.getProductById(request.productId)
         val order = Order(
             user = user,
+            product = product,
             amount = request.amount,
             interestRate = generateOrderInterestRate(),
             orderTerm = OrderTerm(request.term),
-            content = request.content
+            content = request.content,
         )
         return orderRepository.save(order)
     }

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
@@ -7,10 +7,6 @@ import io.fana.cruel.domain.base.BaseEntity
 import io.fana.cruel.domain.order.exception.InvalidOrderStatusException
 import io.fana.cruel.domain.product.domain.Product
 import io.fana.cruel.domain.user.domain.User
-import org.hibernate.envers.Audited
-import org.hibernate.envers.NotAudited
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import javax.persistence.Column
@@ -23,6 +19,10 @@ import javax.persistence.Index
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+import org.hibernate.envers.Audited
+import org.hibernate.envers.NotAudited
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
 
 @Table(
     name = "orders",
@@ -39,6 +39,7 @@ import javax.persistence.Table
 @Entity
 @Audited
 class Order(
+    @NotAudited
     @ManyToOne
     @JoinColumn(
         name = "product_id",

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
@@ -39,13 +39,13 @@ import org.springframework.data.annotation.LastModifiedDate
 @Entity
 @Audited
 class Order(
-    @NotAudited
     @ManyToOne
     @JoinColumn(
         name = "product_id",
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT),
         nullable = false
     )
+    @NotAudited
     val product: Product,
 
     @ManyToOne

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/domain/Order.kt
@@ -5,6 +5,7 @@ import io.fana.cruel.core.type.OrderStatus
 import io.fana.cruel.domain.admin.domain.Admin
 import io.fana.cruel.domain.base.BaseEntity
 import io.fana.cruel.domain.order.exception.InvalidOrderStatusException
+import io.fana.cruel.domain.product.domain.Product
 import io.fana.cruel.domain.user.domain.User
 import org.hibernate.envers.Audited
 import org.hibernate.envers.NotAudited
@@ -27,6 +28,8 @@ import javax.persistence.Table
     name = "orders",
     indexes = [
         Index(name = "idx_orders_user_id", columnList = "user_id"),
+        Index(name = "idx_orders_product_id", columnList = "product_id"),
+        // TODO: covered index
         Index(name = "idx_orders_status", columnList = "status"),
         Index(name = "idx_orders_delay_status", columnList = "delay_status"),
         Index(name = "idx_orders_interest_rate", columnList = "interest_rate"),
@@ -36,6 +39,14 @@ import javax.persistence.Table
 @Entity
 @Audited
 class Order(
+    @ManyToOne
+    @JoinColumn(
+        name = "product_id",
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT),
+        nullable = false
+    )
+    val product: Product,
+
     @ManyToOne
     @JoinColumn(
         name = "user_id",

--- a/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/infra/JpaOrderRepository.kt
+++ b/cruel-domain-mysql/src/main/kotlin/io/fana/cruel/domain/order/infra/JpaOrderRepository.kt
@@ -3,10 +3,27 @@ package io.fana.cruel.domain.order.infra
 import io.fana.cruel.domain.order.domain.Order
 import io.fana.cruel.domain.order.domain.OrderRepository
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface JpaOrderRepository : OrderRepository, JpaRepository<Order, Long> {
+    @Query(
+        """
+            SELECT o
+            FROM Order o
+            JOIN FETCH o.product
+            WHERE o.user.id = :userId
+        """
+    )
     override fun findAllByUserId(userId: Long): List<Order>
 
+    @Query(
+        """
+            SELECT o
+            FROM Order o
+            JOIN FETCH o.product
+            where o.id = :orderId
+        """
+    )
     override fun findOrderById(orderId: Long): Order?
 
     override fun save(order: Order): Order

--- a/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/CreateOrderServiceTest.kt
+++ b/cruel-domain-mysql/src/test/kotlin/io/fana/cruel/domain/order/application/CreateOrderServiceTest.kt
@@ -5,6 +5,8 @@ import io.fana.cruel.core.type.OrderStatus
 import io.fana.cruel.domain.order.domain.Order
 import io.fana.cruel.domain.order.domain.OrderRepository
 import io.fana.cruel.domain.order.domain.OrderTerm
+import io.fana.cruel.domain.product.application.GetProductService
+import io.fana.cruel.domain.product.domain.Product
 import io.fana.cruel.domain.user.application.GetUserService
 import io.fana.cruel.domain.user.domain.User
 import io.kotest.core.spec.IsolationMode
@@ -18,9 +20,11 @@ internal class CreateOrderServiceTest : BehaviorSpec({
 
     val orderRepository = mockk<OrderRepository>()
     val getUserService = mockk<GetUserService>()
+    val getProductService = mockk<GetProductService>()
     val createOrderService = CreateOrderService(
         orderRepository = orderRepository,
         getUserService = getUserService,
+        getProductService = getProductService,
     )
     val fixture = kotlinFixture()
     val userFixture = fixture<User>()
@@ -30,8 +34,10 @@ internal class CreateOrderServiceTest : BehaviorSpec({
         factory<OrderTerm> { OrderTerm(validOrderTerm) }
         property(Order::content) { content }
     }
+    val productFixture = fixture<Product>()
     val orderRequest = CreateOrderRequest(
         userId = userFixture.id,
+        productId = productFixture.id,
         amount = orderFixture.amount,
         term = validOrderTerm,
         content = content,
@@ -39,6 +45,7 @@ internal class CreateOrderServiceTest : BehaviorSpec({
 
     given("주문 요청이 주어졌을 때") {
         every { getUserService.getUserById(userFixture.id) } returns userFixture
+        every { getProductService.getProductById(productFixture.id) } returns productFixture
 
         `when`("주문을 생성하면") {
             every { orderRepository.save(orderFixture) } returns orderFixture


### PR DESCRIPTION
* ISSUE: [ISSUE-25](https://github.com/chunghwanyoon/cruel/issues/25)

## 변경 사항
- 주문을 상품 단위로 할 수 있도록 변경
- 주문이 응답으로 나가는 API에 상품 정보 추가

## 체크 리스트
- [ ] 정상 동작 확인
- [ ] 테스트 작성
- [ ] 주석 및 문서 수정
